### PR TITLE
Reimplement the extension inspired by matplotlib's plot directive

### DIFF
--- a/doc/gmtplot.rst
+++ b/doc/gmtplot.rst
@@ -16,7 +16,7 @@ The following RST code:
 .. code-block:: bash
 
     .. gmt-plot::
-        :figure: example_02.png
+        :language: bash
 
         ps=example_02.ps
         gmt set FONT_TITLE 30p MAP_ANNOT_OBLIQUE 0
@@ -37,7 +37,7 @@ The following RST code:
 is executed by sphinx and turned into:
 
 .. gmt-plot::
-    :figure: example_02.png
+    :language: bash
 
     ps=example_02.ps
     gmt set FONT_TITLE 30p MAP_ANNOT_OBLIQUE 0

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -262,9 +262,10 @@ def render_figure(code, code_dir, language, output_dir, output_base):
 def guess_language(filename):
     """Guess language from suffix of the script."""
     suffix = Path(filename).suffix
-    if suffix in ["sh", "bash"]:
+    print(suffix)
+    if suffix in [".sh", ".bash"]:
         return "bash"
-    elif suffix == "py":
+    elif suffix == ".py":
         return "python"
     else:
         raise ValueError("Cannot guess language from {}".format(filename))

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -74,6 +74,8 @@ TEMPLATE = """
     {% for option in code_opts -%}
     {{ option }}
     {% endfor %}
+{%- else %}
+:download:`Source Code <{{ code }}>`
 {%- endif %}
 
 .. figure:: {{ image }}

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -134,9 +134,9 @@ def _set_gmt_datadir(cwd):
 def _reset_gmt_datadir(old_gmt_datadir):
     """Reset environment variable GMT_DATADIR to its old value."""
     if old_gmt_datadir:
-        os.environ['GMT_DATADIR'] = old_gmt_datadir
+        os.environ["GMT_DATADIR"] = old_gmt_datadir
     else:
-        del os.environ['GMT_DATADIR']
+        del os.environ["GMT_DATADIR"]
 
 
 def _search_images(cwd):
@@ -368,7 +368,9 @@ class GMTPlotDirective(Directive):
 
             # Get absolute path of the script
             if config.gmtplot_basedir:  # relative to gmtplot_basedir
-                code_file = Path(env.app.srcdir, config.gmtplot_basedir, self.arguments[0])
+                code_file = Path(
+                    env.app.srcdir, config.gmtplot_basedir, self.arguments[0]
+                )
             elif Path(self.arguments[0]).is_absolute():  # relative to source directory
                 code_file = Path(env.app.srcdir, self.arguments[0][1:])
             else:  # relative to current rst file's path

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -340,6 +340,7 @@ class GMTPlotDirective(Directive):
 
         counter = env.new_serialno("gmtplot")
         output_base = "{}-gmtplot-{}".format(rst_file.stem, counter)
+        caption = ""
 
         if self.arguments:  # load codes from a file
             # Guess langauge from suffix of the script
@@ -363,16 +364,12 @@ class GMTPlotDirective(Directive):
             self.options.setdefault("language", config.highlight_language)
             code_basedir = cwd
             code = textwrap.dedent("\n".join(map(str, self.content)))
-            caption = ""
+            if "caption" in self.options:
+                caption = self.options["caption"]
 
         # determine unique code filename under current working directory
         suffix = get_suffix_from_language(self.options["language"])
         code_file = Path(cwd, "{}.{}".format(output_base, suffix))
-
-        # determine figure captions
-        if "caption" in self.options:
-            caption = self.options["caption"]
-        caption = "\n".join("      " + line.strip() for line in caption.split("\n"))
 
         if self.options["show-code"]:
             code_opts = []

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -396,7 +396,7 @@ class GMTPlotDirective(Directive):
         )
         # determine how to link to files in builddir from the RST file
         # use os.path.relpath rather than relative_to!
-        builddir_link = Path("/", os.path.relpath(builddir, env.app.srcdir))
+        builddir_link = Path("/", os.path.relpath(str(builddir), env.app.srcdir))
 
         # copy script to builddir
         builddir.mkdir(parents=True, exist_ok=True)

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -346,12 +346,12 @@ class GMTPlotDirective(Directive):
 
             # Get absolute path of the script
             if config.gmtplot_basedir:  # relative to gmtplot_basedir
-                code_basedir = Path(env.app.srcdir, config.gmtplot_basedir)
+                code_file = Path(env.app.srcdir, config.gmtplot_basedir, self.arguments[0])
             elif Path(self.arguments[0]).is_absolute():  # relative to source directory
-                code_basedir = Path(env.app.srcdir)
+                code_file = Path(env.app.srcdir, self.arguments[0][1:])
             else:  # relative to current rst file's path
-                code_basedir = Path(cwd)
-            code_file = Path(code_basedir, self.arguments[0]).absolute()
+                code_file = Path(cwd, self.arguments[0])
+            code_file = code_file.absolute()
             code_basedir = code_file.parent
             code = code_file.read_text(encoding="utf-8")
 

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -331,6 +331,7 @@ class GMTPlotDirective(Directive):
 
         # set options to default values if not specified
         self.options.setdefault("show-code", config.gmtplot_show_code)
+        self.options.setdefault("align", config.gmtplot_figure_align)
 
         # Get the name of the rst source file we are currently processing
         rst_file = Path(document["source"])
@@ -435,6 +436,7 @@ def setup(app):
     app.add_directive("gmt-plot", GMTPlotDirective)
     app.add_config_value("gmtplot_basedir", None, True)
     app.add_config_value("gmtplot_show_code", True, True)
+    app.add_config_value("gmtplot_figure_align", "center", True)
     metadata = {
         "version": "0.1.0",
         "parallel_read_safe": True,

--- a/gmtsphinxext/gmtplot.py
+++ b/gmtsphinxext/gmtplot.py
@@ -262,7 +262,6 @@ def render_figure(code, code_dir, language, output_dir, output_base):
 def guess_language(filename):
     """Guess language from suffix of the script."""
     suffix = Path(filename).suffix
-    print(suffix)
     if suffix in [".sh", ".bash"]:
         return "bash"
     elif suffix == ".py":


### PR DESCRIPTION
Fixes #3, #4, #5, #6.

Hi @leouieda , I tried to rewrite the extension based on matplotlib's plot extension.

Features of current version:
- support both inline codes and loading codes from a script file (Fixes #3)
- can hide the code via `:show-code: false` option (Fixes #5)
- the gmt-plot directive is converted to the equivalent `literalinclude` and `figure` directives to make it flexible for both HTML and LaTeX outputs (Fixes #6)
- Link to source code if source code isn't shown (Fixes #4)
- can execute both bash and python (gmt-python) scripts
- for bash scripts, support both classic and modern modes. The script must generate a PNG file or a PS file.
- for gmt-python scripts, the last statement must call `show()` or `savefig()`(the saved figure file must be in PNG format).

I tested it locally and it works well if the codes can generate an image file correctly. Although there're still some exceptions to be handled, I think this version can replace the old version now.